### PR TITLE
fix: NewSkipError -> NewBreakError

### DIFF
--- a/pkg/blaker/blaker.go
+++ b/pkg/blaker/blaker.go
@@ -45,7 +45,7 @@ func (b *Blaker) RunCmd(input *RunCmdInput) (cmd.Status, error) {
 		return cmd.Status{}, err
 	}
 	if breakTime != nil && b.clock.Now().After(*breakTime) {
-		return cmd.Status{}, NewSkipError(*breakTime, input)
+		return cmd.Status{}, NewBreakError(*breakTime, input)
 	}
 
 	options := cmd.Options{

--- a/pkg/blaker/errors.go
+++ b/pkg/blaker/errors.go
@@ -11,7 +11,7 @@ type BreakError struct {
 	input     *RunCmdInput
 }
 
-func NewSkipError(breakTime time.Time, input *RunCmdInput) *BreakError {
+func NewBreakError(breakTime time.Time, input *RunCmdInput) *BreakError {
 	return &BreakError{
 		breakTime: breakTime,
 		input:     input,


### PR DESCRIPTION
I think it's an oversight and it's better to match it with "NewBreakError"
. -> https://github.com/cynipe/blaker/commit/48f3dd8b0c6a337d204ac6d7a29fa02fa3b53bc1

