### PR TITLE
refactor and make useful from other library

### DIFF
--- a/cmd/blaker/main.go
+++ b/cmd/blaker/main.go
@@ -95,7 +95,7 @@ func run(ctx *cli.Context) error {
 func handleError(err error, ctx *cli.Context, status cmd.Status) error {
 	if err != nil {
 		switch err.(type) {
-		case *blaker.BreakError:
+		case *blaker.BreakTimeAfterError:
 			// on break-time
 			if ctx.Bool("error-on-break") {
 				return cli.NewExitError(err, breakError)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cynipe/blaker
+module github.com/lowbridgee/blaker
 
 go 1.12
 

--- a/pkg/blaker/blaker.go
+++ b/pkg/blaker/blaker.go
@@ -45,7 +45,7 @@ func (b *Blaker) RunCmd(input *RunCmdInput) (cmd.Status, error) {
 	if err != nil {
 		switch err.(type) {
 		case *BreakTimeAfterError:
-			return cmd.Status{}, errors.Wrap(err, fmt.Sprintf(" skipped command: `%s %s`",
+			return cmd.Status{}, errors.Wrap(err, fmt.Sprintf("skipped command: `%s %s` ",
 				input.Command,
 				strings.Join(input.Args, " "),
 			))

--- a/pkg/blaker/errors.go
+++ b/pkg/blaker/errors.go
@@ -2,26 +2,21 @@ package blaker
 
 import (
 	"fmt"
-	"strings"
 	"time"
 )
 
-type BreakError struct {
+type BreakTimeAfterError struct {
 	breakTime time.Time
-	input     *RunCmdInput
 }
 
-func NewBreakError(breakTime time.Time, input *RunCmdInput) *BreakError {
-	return &BreakError{
+func NewBreakTimeAfterError(breakTime time.Time) *BreakTimeAfterError {
+	return &BreakTimeAfterError{
 		breakTime: breakTime,
-		input:     input,
 	}
 }
 
-func (s *BreakError) Error() string {
-	return fmt.Sprintf("the command cannot be run after %s. skipped command: `%s %s`",
+func (s *BreakTimeAfterError) Error() string {
+	return fmt.Sprintf("the command cannot be run after %s.",
 		s.breakTime.Format(time.RFC3339),
-		s.input.Command,
-		strings.Join(s.input.Args, " "),
 	)
 }


### PR DESCRIPTION
- added the division of the responsibility of RunCmd
- added support for using blaker from outside of command execution
- BreakError -> BreakTimeAfterError

log

```
skipped command: `echo hey` : the command cannot be run after 2020-01-01T10:00:00+09:00.
```